### PR TITLE
ci: use deploy to run deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,13 @@ script:
   - npm run lint
   - npm test
   - npx codecov
+deploy:
+  provider: script
+  script: npm run deploy
+  on:
+    branch: master
 after_success:
   - npx semantic-release
-  - npm run deploy
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
To avoid being triggered on pull requests the deploy script should be run as a deploy job and not `after_success`, which is trigger every time:

https://docs.travis-ci.com/user/deployment/#pull-requests